### PR TITLE
Add class WSGIServerV6 in order to support IPv6

### DIFF
--- a/rostful/src/rostful/server.py
+++ b/rostful/src/rostful/server.py
@@ -639,6 +639,14 @@ class RostfulServer:
 
 import argparse
 from wsgiref.simple_server import make_server
+from wsgiref.simple_server import WSGIServer
+
+
+class WSGIServerV6(WSGIServer):
+	'''
+	  This class is only use to override address_family in order to allow IPv6 server
+	'''
+	address_family = socket.AF_INET6
 
 def servermain():
 	rospy.init_node('rostful_server', anonymous=True, disable_signals=True)
@@ -657,6 +665,7 @@ def servermain():
 	parser.add_argument('--jwt', action='store_true', default=False, help='This argument enables the use of JWT to guarantee a secure transmission')
 	parser.add_argument('--jwt-key', default='ros', help='This arguments sets the key to encode/decode the data')
 	parser.add_argument('--jwt-alg', default='HS256', help='This arguments sets the algorithm to encode/decode the data')
+	parser.add_argument('--ipv6', action='store_true', default=False, help="This argument starts the server with an IPv6 instead of IPv4")
 
 	args = parser.parse_args(rospy.myargv()[1:])
 
@@ -669,8 +678,12 @@ def servermain():
 
 	try:
 		server = RostfulServer(args)
-
-		httpd = make_server(args.host, args.port, server.wsgifunc())
+		
+		if args.ipv6:
+			httpd = make_server(args.host, args.port, server.wsgifunc(), server_class=WSGIServerV6)
+		else:
+			httpd = make_server(args.host, args.port, server.wsgifunc())
+			
 		rospy.loginfo('rostful_server: Started server on  %s:%d', args.host, args.port)
 
 		#Wait forever for incoming http requests


### PR DESCRIPTION
## Problem
When testing [Husarnet](https://husarnet.com/), which  is a IPv6 network, I noticed that I could not create a rostful server if the host argument was an ipv6. It gets the following error:

` [Errno -9] Address family for hostname not supported`

## Solution

I've made a new class that inherits from `WSGIServer`. At the same time, this class inherits from `HTTPServer` and this from `TCPServer` which by default has `address_family = socket.AF_INET`.
This new class changes this attribute to `address_family = socket.AF_INET6`. This behaviour can be selected by adding the argument `--ipv6`.  If we want to use IPv6 the launch file will look something like this:

```xml
<node pkg="rostful" type="server" name="$(arg node_name)" output="screen" args="--ipv6 --host $(arg host) -p $(arg port)
      --topics /topic_name">
  </node>
```