### PR TITLE
Changed python-catkin-pkg to python3 to solve rosdep installation error

### DIFF
--- a/rostful/package.xml
+++ b/rostful/package.xml
@@ -32,7 +32,7 @@
   <test_depend>rosunit</test_depend>
 
   <!-- documentation dependencies -->
-  <build_depend>python-catkin-pkg</build_depend>
+  <build_depend>python3-catkin-pkg</build_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml" />


### PR DESCRIPTION
When running rosdep install from paths an error related to the python-catkin-pkg appeared. To solve it, the build_dependency has been changed to python3-catkin-pkg.